### PR TITLE
Infinite scroll loading with UI improvements

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -68,7 +68,7 @@ function App() {
 
   return (
     <Container maxWidth="xl">
-      <Grid container columnSpacing={2} rowSpacing={4}>
+      <Grid container columnSpacing={2} rowSpacing={4} alignItems="stretch">
         {loading && !data // If it's loading and data is still not there (initial load)
           ? Array.from({ length: 12 }).map((_, index) => (
               <Grid item xs={12} sm={6} md={4} lg={3} key={index}>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,7 +32,9 @@ function App() {
     variables: { cursor: null, first: 40 },
   })
 
+  // Custom loading state to show skeleton UI at correct time
   const [isLoadingMore, setIsLoadingMore] = useState(false)
+
   const loader = useRef(null)
 
   const fetchMoreCallback = useCallback(() => {
@@ -61,26 +63,32 @@ function App() {
 
   useInfiniteScroll(loader, fetchMoreCallback)
 
-  if (loading) return <div>loading...</div>
+  // Todo: Add useful error handling UI
   if (error) return <div>error</div>
 
   return (
     <Container maxWidth="xl">
       <Grid container columnSpacing={2} rowSpacing={4}>
-        {data.marketplaceListings.edges.map((d: any) => {
-          const { logoUrl, logoBackgroundColor, name, shortDescription } =
-            d.node
-          return (
-            <Grid item xs={12} sm={6} md={4} lg={3} key={d.cursor}>
-              <AvatarCard
-                cardName={name}
-                imgUrl={logoUrl}
-                imgBgColor={logoBackgroundColor}
-                description={shortDescription}
-              />
-            </Grid>
-          )
-        })}
+        {loading && !data // If it's loading and data is still not there (initial load)
+          ? Array.from({ length: 12 }).map((_, index) => (
+              <Grid item xs={12} sm={6} md={4} lg={3} key={index}>
+                <AvatarCardSkeleton />
+              </Grid>
+            ))
+          : data.marketplaceListings.edges.map((d: any) => {
+              const { logoUrl, logoBackgroundColor, name, shortDescription } =
+                d.node
+              return (
+                <Grid item xs={12} sm={6} md={4} lg={3} key={d.cursor}>
+                  <AvatarCard
+                    cardName={name}
+                    imgUrl={logoUrl}
+                    imgBgColor={logoBackgroundColor}
+                    description={shortDescription}
+                  />
+                </Grid>
+              )
+            })}
 
         {/* Intersection Obeserver Element  */}
         <div ref={loader} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,8 @@ import { gql } from '@apollo/client'
 import { Container, Grid } from '@mui/material'
 import AvatarCard from './components/AvatarCard'
 import useInfiniteScroll from './hooks/useInfiniteScroll'
-import { useCallback, useRef } from 'react'
+import { useCallback, useRef, useState } from 'react'
+import AvatarCardSkeleton from './components/AvatarCardSkeleton'
 
 export const avatarQuery = gql`
   query MarketPlaceQuery($cursor: String, $first: Int = 40) {
@@ -31,15 +32,18 @@ function App() {
     variables: { cursor: null, first: 40 },
   })
 
+  const [isLoadingMore, setIsLoadingMore] = useState(false)
   const loader = useRef(null)
 
   const fetchMoreCallback = useCallback(() => {
     if (data && data.marketplaceListings.pageInfo.hasNextPage) {
+      setIsLoadingMore(true)
       fetchMore({
         variables: {
           cursor: data.marketplaceListings.pageInfo.endCursor,
         },
         updateQuery: (prev, { fetchMoreResult }) => {
+          setIsLoadingMore(false)
           if (!fetchMoreResult) return prev
           return {
             marketplaceListings: {
@@ -80,6 +84,14 @@ function App() {
 
         {/* Intersection Obeserver Element  */}
         <div ref={loader} />
+
+        {isLoadingMore
+          ? Array.from({ length: 20 }).map((_, index) => (
+              <Grid item xs={12} sm={6} md={4} lg={3} key={index}>
+                <AvatarCardSkeleton />
+              </Grid>
+            ))
+          : null}
       </Grid>
     </Container>
   )

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,8 +4,8 @@ import { Container, Grid } from '@mui/material'
 import AvatarCard from './components/AvatarCard'
 
 export const avatarQuery = gql`
-  query MarketPlaceQuery {
-    marketplaceListings(first: 40) {
+  query MarketPlaceQuery($cursor: String, $first: Int = 40) {
+    marketplaceListings(first: $first, after: $cursor) {
       edges {
         cursor
         node {
@@ -15,12 +15,19 @@ export const avatarQuery = gql`
           shortDescription
         }
       }
+      # GQL pagination
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
     }
   }
 `
 
 function App() {
-  const { loading, error, data } = useQuery(avatarQuery)
+  const { loading, error, data, fetchMore } = useQuery(avatarQuery, {
+    variables: { cursor: null, first: 40 },
+  })
 
   if (loading) return <div>loading...</div>
   if (error) return <div>error</div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -67,7 +67,7 @@ function App() {
   if (error) return <div>error</div>
 
   return (
-    <Container maxWidth="xl">
+    <Container maxWidth="xl" sx={{ py: 3 }}>
       <Grid container columnSpacing={2} rowSpacing={4} alignItems="stretch">
         {loading && !data // If it's loading and data is still not there (initial load)
           ? Array.from({ length: 12 }).map((_, index) => (

--- a/src/components/AvatarCard.tsx
+++ b/src/components/AvatarCard.tsx
@@ -21,6 +21,7 @@ const AvatarCard: React.FC<AvatarCardProps> = ({
     <Card
       raised={true}
       sx={{
+        height: '100%',
         display: 'flex',
         flexDirection: 'column',
         alignItems: 'center',

--- a/src/components/AvatarCard.tsx
+++ b/src/components/AvatarCard.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Box, Card, CardMedia, CardContent } from '@mui/material'
-import EllipsisContentTypographyProps from './EllipsisContentTypography'
+import EllipsisContentTypography from './EllipsisContentTypography'
 
 interface AvatarCardProps {
   cardName: string
@@ -47,12 +47,12 @@ const AvatarCard: React.FC<AvatarCardProps> = ({
       </Box>
       <CardContent sx={{ p: 3, width: '100%' }}>
         <Box>
-          <EllipsisContentTypographyProps variant="h6" sx={{ mb: 1 }} lines={2}>
+          <EllipsisContentTypography variant="h6" sx={{ mb: 1 }} lines={2}>
             {cardName}
-          </EllipsisContentTypographyProps>
-          <EllipsisContentTypographyProps variant="body1" lines={3}>
+          </EllipsisContentTypography>
+          <EllipsisContentTypography variant="body1" lines={3}>
             {description}
-          </EllipsisContentTypographyProps>
+          </EllipsisContentTypography>
         </Box>
       </CardContent>
     </Card>

--- a/src/components/AvatarCard.tsx
+++ b/src/components/AvatarCard.tsx
@@ -25,7 +25,10 @@ const AvatarCard: React.FC<AvatarCardProps> = ({
         display: 'flex',
         flexDirection: 'column',
         alignItems: 'center',
-        maxWidth: 400,
+        maxWidth: {
+          xs: '100%',
+          sm: 400,
+        },
         borderRadius: 5,
       }}
     >

--- a/src/components/AvatarCardSkeleton.tsx
+++ b/src/components/AvatarCardSkeleton.tsx
@@ -1,0 +1,16 @@
+import { Card, CardContent, Skeleton } from '@mui/material'
+const AvatarCardSkeleton = () => {
+  return (
+    <Card>
+      <Skeleton variant="rectangular" width="100%" height={250} />
+      <CardContent>
+        <Skeleton variant="text" sx={{ fontSize: '2rem' }} />
+        <Skeleton variant="text" />
+        <Skeleton variant="text" />
+        <Skeleton variant="text" />
+      </CardContent>
+    </Card>
+  )
+}
+
+export default AvatarCardSkeleton

--- a/src/components/EllipsisContentTypography.tsx
+++ b/src/components/EllipsisContentTypography.tsx
@@ -10,7 +10,7 @@ interface EllipsisContentTypographyProps extends TypographyProps {
 
 const EllipsisContentTypography = styled(
   Typography
-)<EllipsisContentTypographyProps>(({ theme, lines }) => ({
+)<EllipsisContentTypographyProps>(({ lines }) => ({
   overflow: 'hidden',
   textOverflow: 'ellipsis',
   display: '-webkit-box',

--- a/src/hooks/useInfiniteScroll.tsx
+++ b/src/hooks/useInfiniteScroll.tsx
@@ -1,0 +1,35 @@
+import { MutableRefObject, useEffect, useRef } from 'react'
+
+type useInfiniteScrollType = (
+  ref: MutableRefObject<HTMLElement | null>,
+  callback: () => void
+) => void
+
+const useInfiniteScroll: useInfiniteScrollType = (ref, callback) => {
+  const observer = useRef<IntersectionObserver | null>(null)
+
+  useEffect(() => {
+    if (observer.current) {
+      observer.current.disconnect()
+    }
+
+    observer.current = new IntersectionObserver((entries) => {
+      const first = entries[0]
+      if (first.isIntersecting) {
+        callback()
+      }
+    })
+
+    if (ref.current) {
+      observer.current.observe(ref.current)
+    }
+
+    return () => {
+      if (observer.current) {
+        observer.current.disconnect()
+      }
+    }
+  }, [ref, callback])
+}
+
+export default useInfiniteScroll


### PR DESCRIPTION
## Changes implemented
- Modify GQL query to get cursor and page info and accept variable for first item count (GQL best practise to not hard code variables).
- Created a rudimentary infinite scrolling hook.
- Added skeleton UI for loading states.
- Adjusted cards to have the same height.
- Fixed cards width on mobile view.
- Fixed component that was using the interface instead of using the component

## Considerations & Improvements

### Error handling
- Error handling UI won't really be noticeable in its current state.
- May want to add a retry mechanism for refetching data on errors.

### Infinite Scrolling Hook
This is really just a rudimentary implementation. Using a 3rd party library may be more beneficial. Things that may need to be looked into include:
- Scroll position: after new data is loaded it may be a bit jumpy depending on user behaviour and the time the items take to load/render.
- Duplicate requests: scrolling fast to the bottom, up and down again may trigger additional requests for the same cursor.
- Debouncing/throttling fetches: users scrolling fast could trigger too many requests.
- Prefetch data: we may want to prefetch data at an earlier position while scrolling

